### PR TITLE
Remove duplicate value assignation on copy

### DIFF
--- a/controllers/src/copy_controller/index.js
+++ b/controllers/src/copy_controller/index.js
@@ -39,7 +39,6 @@ export class CopyController extends Controller {
     this.showCopied()
 
     if (this.sourceTarget.value) {
-      this.sourceTarget.value = ''
       this.sourceTarget.value = this.value
       this.sourceTarget.focus()
     } else {


### PR DESCRIPTION
The `this.sourceTarget.value` is assigned twice in a row.
I think the first assignation is not needed.